### PR TITLE
Add FiveM -> Ped comms

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "fivem/cfx-server-data"]
 	path = fivem/cfx-server-data
 	url = https://github.com/citizenfx/cfx-server-data.git
+	ignore = dirty

--- a/fivem/Start-Server.ps1
+++ b/fivem/Start-Server.ps1
@@ -9,7 +9,7 @@ param(
 # Build
 Push-Location -Path "$PSScriptRoot\..\src"
 try {
-    & dotnet build Missions.sln
+    & dotnet build PedGPT.sln
 }
 finally {
     Pop-Location

--- a/src/IntelliPed.Core/IntelliPed.Core.csproj
+++ b/src/IntelliPed.Core/IntelliPed.Core.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.7.0-preview" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\IntelliPed.FiveM.Messages\IntelliPed.FiveM.Messages.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/IntelliPed.Core/Plugins/NavigationPlugin.cs
+++ b/src/IntelliPed.Core/Plugins/NavigationPlugin.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel;
+using System.Net.Http.Json;
 using System.Numerics;
+using IntelliPed.FiveM.Messages.Navigation;
 using Microsoft.SemanticKernel;
 
 namespace IntelliPed.Core.Plugins;
@@ -12,7 +14,21 @@ public class NavigationPlugin
         Kernel kernel,
         [Description("The co-ordinate.")] Vector3 coordinate)
     {
-        await Task.Delay(1000);
+        HttpClient httpClient = new();
+
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("http://localhost:5000/api/navigation/move-to-position", new MoveToPositionRequest
+        {
+            X = coordinate.X,
+            Y = coordinate.Y,
+            Z = coordinate.Z,
+        });
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.WriteLine($"Failed to navigate to ({coordinate.X}, {coordinate.Y}, {coordinate.Z})");
+            return "Failed to navigate.";
+        }
+
         Console.WriteLine($"Successfully navigated to ({coordinate.X}, {coordinate.Y}, {coordinate.Z})");
         return "Successfully navigated.";
     }

--- a/src/IntelliPed.FiveM.Messages/IntelliPed.FiveM.Messages.csproj
+++ b/src/IntelliPed.FiveM.Messages/IntelliPed.FiveM.Messages.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Navigation\" />
+  </ItemGroup>
+
+</Project>

--- a/src/IntelliPed.FiveM.Messages/Navigation/MoveToPosition.cs
+++ b/src/IntelliPed.FiveM.Messages/Navigation/MoveToPosition.cs
@@ -1,0 +1,8 @@
+﻿namespace IntelliPed.FiveM.Messages.Navigation;
+
+public record MoveToPositionRequest
+{
+    public float X { get; set; }    
+    public float Y { get; set; }    
+    public float Z { get; set; }
+}

--- a/src/IntelliPed.FiveM.Server/Controllers/NavigationController.cs
+++ b/src/IntelliPed.FiveM.Server/Controllers/NavigationController.cs
@@ -1,0 +1,27 @@
+﻿using CitizenFX.Core.Native;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using IntelliPed.FiveM.Messages.Navigation;
+
+namespace IntelliPed.FiveM.Server.Controllers;
+
+[Route("api/[controller]")]
+public class NavigationController : Controller
+{
+    [HttpPost("move-to-position")]
+    public async Task<IActionResult> MoveToPosition([FromBody] MoveToPositionRequest request)
+    {
+        string? resourceName = null;
+        TaskCompletionSource<bool> taskCompletionSource = new();
+
+        GameScript.Instance.ExecuteOnGameThread(() =>
+        {
+            resourceName = API.GetCurrentResourceName();
+            taskCompletionSource.SetResult(true);
+        });
+
+        await taskCompletionSource.Task;
+
+        return Ok();
+    }
+}

--- a/src/IntelliPed.FiveM.Server/GameScript.cs
+++ b/src/IntelliPed.FiveM.Server/GameScript.cs
@@ -1,0 +1,34 @@
+﻿using CitizenFX.Core;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using System;
+
+namespace IntelliPed.FiveM.Server;
+
+public class GameScript : BaseScript
+{
+    public static GameScript Instance { get; private set; } = null!;
+
+    private readonly ConcurrentQueue<Action> _actions = new ConcurrentQueue<Action>();
+
+    public GameScript()
+    {
+        Instance = this;
+        Tick += OnTick;
+    }
+
+    public void ExecuteOnGameThread(Action action)
+    {
+        _actions.Enqueue(action);
+    }
+
+    private async Task OnTick()
+    {
+        while (_actions.TryDequeue(out var action))
+        {
+            action();
+        }
+
+        await Task.FromResult(0); // Yield control back to the game loop
+    }
+}

--- a/src/IntelliPed.FiveM.Server/IntelliPed - Backup.FiveM.Server.csproj
+++ b/src/IntelliPed.FiveM.Server/IntelliPed - Backup.FiveM.Server.csproj
@@ -21,11 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Controllers\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\IntelliPed.FiveM.Messages\IntelliPed.FiveM.Messages.csproj" />
+    <Folder Include="NewFolder\" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/IntelliPed.FiveM.Server/Program.cs
+++ b/src/IntelliPed.FiveM.Server/Program.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using CitizenFX.Core;
+using CitizenFX.Core.Native;
+using IntelliPed.FiveM.Server.Controllers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using Debug = CitizenFX.Core.Debug;
+
+namespace IntelliPed.FiveM.Server;
+
+public class Program : BaseScript
+{
+    [EventHandler("onResourceStart")]
+    private async void OnResourceStart(string resourceName)
+    {
+        if (API.GetCurrentResourceName() != resourceName)
+        {
+            return;
+        }
+
+        IConfigurationRoot config = new ConfigurationBuilder()
+            .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+            .Build();
+
+        IWebHost host = new WebHostBuilder()
+            .UseConfiguration(config)
+            .UseKestrel()
+            .ConfigureServices(services =>
+            {
+                services
+                    .AddMvc()
+                    .AddApplicationPart(typeof(NavigationController).Assembly);
+
+                services.AddSingleton<ObjectPoolProvider>(new DefaultObjectPoolProvider());
+                services.AddSingleton<IHostingEnvironment>(new HostingEnvironment());
+                services.AddSingleton<DiagnosticSource>(new DiagnosticListener("IntelliPed"));
+            })
+            .Configure(app =>
+            {
+                app.UseCors();
+                app.UseMvcWithDefaultRoute();
+            })
+            .ConfigureLogging(_ => _.AddConsole())
+            .Build();
+
+        await Task.Run(host.Run);
+
+        Debug.WriteLine("IntelliPed.FiveM.Server has been started.");
+    }
+}

--- a/src/PedGPT.sln
+++ b/src/PedGPT.sln
@@ -3,13 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelliPed.Core", "IntelliPed.Core\IntelliPed.Core.csproj", "{C8547D29-E7DD-4617-9FB8-DFFDEBC391CE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntelliPed.Core", "IntelliPed.Core\IntelliPed.Core.csproj", "{C8547D29-E7DD-4617-9FB8-DFFDEBC391CE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelliPed.ConsoleApp", "IntelliPed.ConsoleApp\IntelliPed.ConsoleApp.csproj", "{F16E4B1E-8D56-4414-94D7-08695692A7EF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntelliPed.ConsoleApp", "IntelliPed.ConsoleApp\IntelliPed.ConsoleApp.csproj", "{F16E4B1E-8D56-4414-94D7-08695692A7EF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelliPed.FiveM.Client", "IntelliPed.FiveM.Client\IntelliPed.FiveM.Client.csproj", "{A8318136-1CB5-4B6E-99F3-25420ADE1331}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelliPed.FiveM.Server", "IntelliPed.FiveM.Server\IntelliPed.FiveM.Server.csproj", "{3BB5874B-0236-4961-BECE-A6D38B92EACE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntelliPed.FiveM.Server", "IntelliPed.FiveM.Server\IntelliPed.FiveM.Server.csproj", "{3BB5874B-0236-4961-BECE-A6D38B92EACE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelliPed.FiveM.Messages", "IntelliPed.FiveM.Messages\IntelliPed.FiveM.Messages.csproj", "{8C3E55A3-6518-45EF-A7E2-F84CBAB064BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{3BB5874B-0236-4961-BECE-A6D38B92EACE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BB5874B-0236-4961-BECE-A6D38B92EACE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BB5874B-0236-4961-BECE-A6D38B92EACE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C3E55A3-6518-45EF-A7E2-F84CBAB064BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C3E55A3-6518-45EF-A7E2-F84CBAB064BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C3E55A3-6518-45EF-A7E2-F84CBAB064BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C3E55A3-6518-45EF-A7E2-F84CBAB064BE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds an ASP.NET Core server running on the FiveM server. Exposing a REST API to allow the agents to communicate with FiveM via Semantic Kernel.

I did attempt to use a gRPC server but there were numerous issues. First was that cannot use `Grpc.AspNetCore` due to the FiveM server running on .NET Standard 2.0. Second was difficulties using `Grpc.Core` which seems to be to do with the library trying to load things from the GAC but the FiveM sandbox environment does not have access to this. 

Almost pivoted to use TypeScript/Node for the FiveM server but ultimately decided against it to avoid having to switch between languages. A REST API is simple enough and does the job anyway.